### PR TITLE
fix: copying foundry.toml to the bounty execution folder

### DIFF
--- a/tests/bounties/src/adder/setup-exec-env.sh
+++ b/tests/bounties/src/adder/setup-exec-env.sh
@@ -13,6 +13,7 @@ alias reth="reth-$RETH_VERSION"
 
 >&2 echo "Setting up Forge project..."
 cp -r src /tmp
+cp foundry.toml /tmp
 cp "$1" /tmp/src/Exploit.sol
 cd /tmp
 


### PR DESCRIPTION
This change is specially needed when the project has external dependencies and we have to add a remappings config in foundry.toml.