### PR TITLE
feat: Move create button to header and apply new visual

### DIFF
--- a/frontend/src/app/explore/page.tsx
+++ b/frontend/src/app/explore/page.tsx
@@ -2,23 +2,18 @@
 import { FC } from "react";
 import {
     Box,
-    Button,
     Center,
     Stack,
     Image,
     Card,
-    Flex,
     Text,
     Anchor,
     SimpleGrid,
-    Group,
     Tooltip,
 } from "@mantine/core";
-import Link from "next/link";
 import { useLatestState } from "../../model/reader";
 import { AppBounty } from "../../model/state";
 import { BountyStatusBadgeGroup } from "../../components/bountyStatus";
-import { HasConnectedAccount } from "../../components/hasConnectedAccount";
 import { useBlockTimestamp } from "../../hooks/block";
 import {
     getBountyStatus,
@@ -116,18 +111,6 @@ const BountyList: FC = () => {
 const Explore: FC = () => {
     return (
         <Stack>
-            <HasConnectedAccount>
-                <Flex
-                    mt="lg"
-                    mr={{ base: "xs", md: "lg" }}
-                    justify="flex-end"
-                    visibleFrom="md"
-                >
-                    <Link href="/bounty/create">
-                        <Button size="lg">Create bounty</Button>
-                    </Link>
-                </Flex>
-            </HasConnectedAccount>
             <Center>
                 <BountyList />
             </Center>

--- a/frontend/src/app/header.tsx
+++ b/frontend/src/app/header.tsx
@@ -6,10 +6,12 @@ import {
     ActionIcon,
     Tooltip,
     Stack,
-    Box,
+    Flex,
+    Divider,
 } from "@mantine/core";
 import { FC } from "react";
 import { RiMoneyDollarCircleLine } from "react-icons/ri";
+import { MdArrowOutward } from "react-icons/md";
 import { HasConnectedAccount } from "../components/hasConnectedAccount";
 import { useMediaQuery } from "@mantine/hooks";
 
@@ -46,24 +48,52 @@ export const Header: FC = () => {
                     </Anchor>
                 </Center>
             </Group>
-            <Group
+            <Flex
+                direction={{ base: "column", sm: "row" }}
                 px={{ base: "xs", md: "lg" }}
                 pb="xs"
-                justify="space-between"
+                justify={{ base: "center", sm: "space-between" }}
                 style={{ minWidth: 360 }}
             >
-                <Box style={{ flexGrow: 1 }}>
+                <Flex
+                    justify={{ base: "center", sm: "flex-start" }}
+                    style={{ flexGrow: 1 }}
+                >
                     <Anchor href="/" underline="never">
                         <Title>🪲 Bug Buster</Title>
                     </Anchor>
-                </Box>
+                </Flex>
 
-                <HasConnectedAccount>
-                    <VoucherNotification />
-                </HasConnectedAccount>
+                <Flex justify={{ base: "center" }} align="center">
+                    <HasConnectedAccount>
+                        <Anchor
+                            href="/bounty/create"
+                            size="lg"
+                            underline="always"
+                        >
+                            Create Bounty
+                        </Anchor>
+                        <MdArrowOutward
+                            style={{
+                                color: "var(--mantine-color-cartesi-cyan-8)",
+                            }}
+                            size="24px"
+                        />
+                    </HasConnectedAccount>
+                </Flex>
 
-                <ConnectButton />
-            </Group>
+                <Divider size="lg" orientation="vertical" mr={"sm"} ml={"sm"} />
+
+                <Flex justify={{ base: "center" }}>
+                    <HasConnectedAccount>
+                        <VoucherNotification />
+                    </HasConnectedAccount>
+                </Flex>
+
+                <Flex justify={{ base: "center" }}>
+                    <ConnectButton />
+                </Flex>
+            </Flex>
         </Stack>
     );
 };


### PR DESCRIPTION
First step when adapting the UX (create button on header) and visual.
![image](https://github.com/user-attachments/assets/8ead155f-7d76-4415-9684-29c32bf9d66b)

Implementation:
![image](https://github.com/user-attachments/assets/2bd84410-3558-4d3c-a600-38e6418258a2)


On mobile:
![image](https://github.com/user-attachments/assets/e9ca3d37-6b40-4fa6-84f1-1647059b74ef)
